### PR TITLE
fixed current_temp on e.g heatit devices

### DIFF
--- a/futurehome2mqtt/CHANGELOG.md
+++ b/futurehome2mqtt/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.3
+
+- Fixes: On some thermostats (e.g Heatit) you are currently not able to readout current
+  measured temperature (room temp sensor or floor temp sensor) directly on the thermostat card as it is on a different device.
+
+Note that the temperature sensor that have the "Set as main temp sensor" checkbox checked in the Futurehome app will be used.
+
 ## 0.3.2
 
 - Added basic HAN sensor support

--- a/futurehome2mqtt/config.json
+++ b/futurehome2mqtt/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Futurehome FIMP integration",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "slug": "futurehome_fimp",
     "description": "Futurehome FIMP integration",
     "url": "https://github.com/runelangseid/hassio-futurehome2mqtt",

--- a/futurehome2mqtt/pyfimptoha/homeassistant.py
+++ b/futurehome2mqtt/pyfimptoha/homeassistant.py
@@ -49,7 +49,7 @@ def create_components(
         # When debugging: Ignore everything except selected_devices if set
         # Format is '<adapter>_<address>', to not have conflicting addresses on different adapters
         if selected_devices and f"{adapter}_{address}" not in selected_devices:
-            print(f"Skipping: {address} {name}")
+            print(f"Skipping: {adapter} {address} {name}")
             continue
 
         print(f"Creating: {adapter} {address} {name}")
@@ -131,7 +131,7 @@ def create_components(
             # Thermostat
             elif service_name == "thermostat":
                 print(f"- Service: {service_name}")
-                status = thermostat.new_thermostat(**common_params, command_topic=command_topic)
+                status = thermostat.new_thermostat(**common_params, command_topic=command_topic, devices=devices)
                 if status:
                     for s in status:
                         statuses.append((s[0], s[1]))
@@ -169,6 +169,7 @@ def get_adapter_name(device):
     else:
         adapter = device["fimp"]["adapter"]
     return adapter
+
 
 def get_room_alias(rooms, room_id):
     room_alias = [room["alias"] for room in rooms if room["id"] == room_id][0]


### PR DESCRIPTION
## 0.3.3

- Fixes: On some thermostats (e.g Heatit) you are currently not able to readout current
  measured temperature (room temp sensor or floor temp sensor) directly on the thermostat card as it is on a different device.

Note that the temperature sensor that have the "Set as main temp sensor" checkbox checked in the Futurehome app will be used.